### PR TITLE
More comments from Michael Richardson.

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -101,9 +101,10 @@
 	    is able to reach hosts on the Internet</li>
 	</ul>
 	<t>
-	  Discoverability here means "discoverable using DNS, or DNS Service Discovery".  As an example, when one host connected to
+	  Discoverability here means "discoverable using DNS, or DNS Service Discovery".  DNS Service Discovery includes multicast
+	  DNS <xref target="RFC6762"/>. As an example, when one host connected to
 	  a specific WiFi network wishes to discover services on hosts connected to that same WiFi network, it can do so using
-	  multicast DNS (RFC6762), which is an example of DNS Service Discovery.  Similarly, when a host on some other network
+	  multicast DNS.  Similarly, when a host on some other network
 	  wishes to discover the same service, it must use DNS-based DNS Service Discovery <xref target="RFC6763"/>.  In both cases,
 	  "discoverable using DNS" means that the host has an entry in the DNS.</t>
 	<t>
@@ -157,6 +158,43 @@
     </section>
 
     <section>
+      <name>Constants</name>
+      <t>
+	This section describes the meaning of and gives default values for various constants used in this document.</t>
+      <dl>
+	<dt>STALE_RA_TIME</dt>
+	<dd>
+	  How long after the last time a router advertisement from a particular has been received before we assume the router is no
+	  longer present. This is a stopgap in case the router is reachable but has silently stopped advertising a prefix; this
+	  situation is unlikely, but if it does happen, new devices joining the infrastructure network will not be able to reach
+	  devices on the stub network until the stub router decides that the router that advertised the usable prefix is stale.</dt>
+	<dt>STUB_PROVIDED_PREFIX_LIFETIME</dt>
+	<dd>
+	  The valid and preferred lifetime the stub router will advertise. This needs to be long enough that a host is actually
+	  willing to use it, and obviously should also be long enough that a missed beacon will not cause the host to stop using
+	  it. The values suggested here allow ten beacons to be missed before the host will stop using the prefix.</dd>
+	<dt>BEACON_INTERVAL</dt>
+	<dd>
+	  How often the stub router will transmit an RA. This should be frequent enough that a missed Router Solicit (e.g. due to
+	  congestion on a WiFi link) will not result in an extremely long outage (assuming the congestion passes before the beacon
+	  is sent, of course).</dd>
+	<dt>PREFIX_DELEGATION_INTERVAL</dt>
+	<dd>
+	  The lifetime a stub router should request for a DHCPv6-delegated prefix. The longer this is, the more prefixes will be
+	  consumed on a network where stub routers are not stable. The lifetime here is chosen to be long enough that a reboot of
+	  the DHCP server will not prevent the prefix being renewed. It happens to coincide with the value of
+	  STUB_PROVIDED_PREFIX_LIFETIME, but the two should not be considered to be equivalent.</dd>
+      </dl>
+      <table><name>Default values for constants</name>
+	<thead><tr><th>Name</th><th>Default value</th></tr></thead>
+	<tbody>
+	  <tr><td>STALE_RA_TIME</td><td>600 seconds (10 minutes)</td></tr>
+	  <tr><td>STUB_PROVIDED_PREFIX_LIFETIME</td><td>1800 seconds (30 minutes)</td></tr>
+	  <tr><td>BEACON_INTERVAL</td><td>180 seconds (3 minutes)</td></tr>
+	  <tr><td>PREFIX_DELEGATION_INTERVAL</td><td>1800 seconds (30 minutes)</td></tr>
+	</tbody>
+      </table>
+    <section>
       <name>Support for adjacent infrastructure links</name>
       <t>
 
@@ -168,8 +206,7 @@
 	<t>
 	  In order to provide IPv6 routing to the stub network, IPv6 addressing must be available on the adjacent infrastructure
 	  link. Ideally such addressing is already present on the link, and need not be provided. However, if it is not present,
-	  the stub router must provide it. The possible states of the on-link prefix on the infrastructure are described here,
-	  along with actions required to be taken to monitor the state.
+	  the stub router must provide it.
 	</t>
 	<section>
 	  <name>Usable On-Link Prefixes</name>
@@ -180,8 +217,9 @@
 	  <t>
 	    A prefix is not considered a usable on-link prefix if it is advertised on the link as on-link, but the 'm' bit is set in
 	    the Router Advertisement message header (<xref target="RFC4861" section="4.2" sectionFormat="comma" />) that contains
-	    the Prefix option. This indicates that node addressibility is being managed using DHCPv6. Such prefixes are not
-	    universally usable.</t>
+	    the Prefix option. This indicates that node addressibility is being managed using DHCPv6. Nodes are not required to
+	    use DHCPv6 to acquire addresses, so a prefix that requires the use of DHCPv6 can't be considered "usable"&mdash;not all
+	    hosts can actually use it.</t>
 	  <t>
 	    A prefix is considered to be advertised on the link if, when a Router Solicit message
 	    (<xref target="RFC4861" section="4.1" sectionFormat="comma"/>) is sent, a Router Advertisement message is received in
@@ -189,113 +227,120 @@
 	    for that prefix.</t>
 	  <t>
 	    After an RA message containing a usable prefix has been received, it can be assumed for some period of time thereafter that the prefix
-	    is still valid on the link. However, prefix lifetimes and router lifetimes are often quite long. The mere fact that a
-	    prefix that has been advertised is still within its valid lifetime does not mean that that prefix is still being
-	    advertised on the link.</t>
+	    is still valid on the link. However, prefix lifetimes and router lifetimes are often quite long. In addition to knowing that
+	    a prefix has been advertised on the link in the past, and is still valid, we must therefore ensure
+	    that at least one router that has advertised this prefix is still alive to respond to router advertisements.</t>
 	</section>
-	<section anchor="state-unknown">
-	  <name>Status of IP addressability on adjacent infrastructure link unknown (STATE-UNKNOWN)</name>
+	<section anchor="state-machine">
+	  <name>State Machine for maintaining a usable on-link prefix on infrastructure</name>
 	  <t>
-	    When the stub router first connects to the adjacent infrastructure link, it MUST begin router discovery.</t>
-	  <t>
-	    If, after router discovery has completed, no usable on-link prefix has been found, the router moves to
-	    STATE-ADVERTISING-USABLE (<xref target="state-advertising-usable"/>).</t>
-	  <t>
-	    If, during router discovery, a usable on-link prefix is found, the router moves to
-	    STATE-USABLE (<xref target="state-usable"/>).</t>
-	</section>
-	<section anchor="state-usable">
-	  <name>IP addressability already present on adjacent infrastructure link (STATE-USABLE)</name>
-	  <t>
-	    This is important because when a new host appears on the adjacent infrastructure link and sends an initial router
-	    solicit, if it does not receive a usable on-link prefix, it will not be able to communicate. Consequently, the stub
-	    router MUST monitor router solicits and advertisements on the link in order to determine whether a prefix that has been
-	    advertised on the link is still being advertised.</t>
-	  <t>
-	    There are several methods that can be used to accomplish this:</t>
-	  <t>
-	    The stub router MUST listen for router advertisements on the adjacent infrastructure link, and record the time at
-	    which each router advertisement was received. A router advertisement that is more than STALE_RA_TIME seconds old MUST be
-	    assumed to no longer be advertised on the link. When the last non-stale router advertisement containing a usable
-	    prefixes on the link is marked stale, the stub router MUST move to STATE-BEGIN-ADVERTISING.</t>
-	  <t>
-	    In addition, for each usable route, the stub router MUST monitor the state of reachability to the router(s) that
-	    advertised it as described in (<xref target="RFC4861" section="7.3.1" sectionFormat="comma"/>) using a ReachableTime
-	    value of no more than 60,000 milliseconds (one minute). The reason for this is that if no router providing the on-link
-	    prefix on the infrastructure link is reachable, then when a new host joins the network, it will have no usable on-link
-	    prefix to use for autoconfiguration, and thus will be unable to communicate with hosts on the stub network.</t>
-	  <t>
-	    The stub router MUST listen for router solicits on the adjacent infrastructure link. When a router solicit is
-	    received, if none of the on-link routers on the adjacent infrastructure link are marked reachable, the stub router
-	    MUST move to the STATE-BEGIN-ADVERTISING state (<xref target="state-begin-advertising"/>).</t>
-	</section>
-	<section anchor="state-begin-advertising">
-	  <name>IP addressability not present on adjacent infrastructure link (STATE-BEGIN-ADVERTISING)</name>
-	  <t>
-	    In this state, the stub router generates its own on-link prefix. This prefix has a valid and preferred lifetime of
-	    STUB_PROVIDED_PREFIX_LIFETIME seconds. This prefix MUST allow for autonomous configuration (SLAAC). The stub router
-	    sends a router advertisement containing this prefix, advertised as a on-link prefix, with the Stub Router bit
-	    (<xref target="I-D.hui-stub-router-ra-flag"/>) set in the prefix header. This RA MUST also include a route to the stub
-	    network. If the stub router is also a normal router (e.g. a home WiFi router), it SHOULD include all other routes that
-	    it is advertising in the RA, if there is space.</t>
-	  <t>
-	    After having sent the initial router advertisement, the stub router moves into the STATE-ADVERTISING-USABLE
-	    state (<xref target="state-advertising-usable"/>).</t>
-	</section>
-	<section anchor="state-advertising-usable">
-	  <name>IP addressability not present on adjacent infrastructure link (STATE-ADVERTISING-USABLE)</name>
-	  <t>
-	    The stub router sends an RA message, formatted as described in <xref target="state-begin-advertising"/>, every
-	    BEACON_INTERVAL seconds.</t>
-	  <t>
-	    The stub router may receive a router advertisement containing a usable on-link prefix on the adjacent infrastructure
-	    link. If the advertised prefix is different than the prefix the stub router is advertising as the on-link usable prefix,
-	    and the Stub Router bit is not set in the advertisement, the stub router moves to STATE-DEPRECATING (xref
-	    target="state-deprecating").</t>
-	  <t>
-	    If the stub router bit is set in the received prefix, then one of the following must be true:</t>
-	  <ul>
-	    <li>
-	      The prefixes are equal. In this case, the stub router remains in STATE-ADVERTISING-USABLE.</li>
-	    <li>
-	      The prefix the stub router is advertising is a ULA <xref target="RFC4193"/>, and the received prefix is a non-ULA
-	      prefix. In this case, the stub router moves into the STATE-DEPRECATING (<xref target="state-deprecating"/>) state.</li>
-	    <li>
-	      Both prefixes are ULA prefixes, and the received prefix, considered as a 128-bit big-endian unsigned integer,
-	      is numerically lower, then the stub router moves to STATE-DEPRECATING (<xref target="state-deprecating"/>.</li>
-	    <li>
-	      Otherwise the router remains in STATE-ADVERTISING-USABLE.</li>
-	  </ul>
-	</section>
-	<section anchor="state-deprecating">
-	  <name>Stub router deprecating its on-link prefix (STATE-DEPRECATING)</name>
-	  <t>When the stub router has detected the availability of an infrastructure-provided on-link prefix on the adjacent
-	    infrastructure link, it continues to advertise its own prefix, but deprecates it:
-	  </t>
-	  <ul>
-	    <li>
-	      the preferred lifetime for this prefix should be set to zero in subsequent advertisements.</li>
-	    <li>
-	      the valid lifetime for this prefix should be reduced with each subsequent advertisement</li>
-	    <li>
-	      the usability of the infrastructure-provided on-link prefix should be monitored as in the STATE-USABLE state;
-	      if during the deprecation period, the stub router detects that there are no longer any usable prefixes on the
-	      link, it MUST return to the STATE-BEGIN-ADVERTISING (xref target="state-advertising-usable") state and resume
-	      advertising its prefix with the valid and preferred lifetimes described there.</li>
-	  </ul>
-	  <t>
-	    In this state, the valid lifetime (VALID) is computed based on three values: the current time when a router
-	    advertisement is being generated (NOW), the time at which the new usable on-link prefix advertisement was received
-	    (DEPRECATE_TIME), and STUB_PROVIDED_PREFIX_LIFETIME. All of these values are in seconds. VALID is computed as follows:
-	  </t>
-	  <t>
-	    VALID = STUB_PROVIDED_PREFIX_LIFETIME - (NOW - DEPRECATE_TIME)
-	  </t>
-	  <t>
-	    If VALID is less than BEACON_INTERVAL, the stub router does not include the deprecated prefix in the router
-	    advertisement. Note that VALID could be less than zero. Otherwise, the prefix is provided in the advertisement, but with
-	    a valid lifetime of VALID.
-	  </t>
+	    The possible states of the on-link prefix on the infrastructure are described here, along with actions required to be
+	    taken to monitor the state. The purpose of the state machine described here is to ensure that at all times, when a
+	    new host arrives on the adjacent infrastructure link, it is able to acquire an IPv6 address on that link.</t>
+	  <section anchor="state-unknown">
+	    <name>Status of IP addressability on adjacent infrastructure link unknown (STATE-UNKNOWN)</name>
+	    <t>
+	      When the stub router first connects to the adjacent infrastructure link, it MUST begin router discovery.</t>
+	    <t>
+	      If, after router discovery has completed, no usable on-link prefix has been found, the router moves to
+	      STATE-ADVERTISING-USABLE (<xref target="state-advertising-usable"/>).</t>
+	    <t>
+	      If, during router discovery, a usable on-link prefix is found, the router moves to
+	      STATE-USABLE (<xref target="state-usable"/>).</t>
+	  </section>
+	  <section anchor="state-usable">
+	    <name>IP addressability already present on adjacent infrastructure link (STATE-USABLE)</name>
+	    <t>
+	      This is important because when a new host appears on the adjacent infrastructure link and sends an initial router
+	      solicit, if it does not receive a usable on-link prefix, it will not be able to communicate. Consequently, the stub
+	      router MUST monitor router solicits and advertisements on the link in order to determine whether a prefix that has been
+	      advertised on the link is still being advertised.</t>
+	    <t>
+	      There are several methods that can be used to accomplish this:</t>
+	    <t>
+	      The stub router MUST listen for router advertisements on the adjacent infrastructure link, and record the time at
+	      which each router advertisement was received. A router advertisement that is more than STALE_RA_TIME seconds old MUST be
+	      assumed to no longer be advertised on the link. When the last non-stale router advertisement containing a usable
+	      prefixes on the link is marked stale, the stub router MUST move to STATE-BEGIN-ADVERTISING.</t>
+	    <t>
+	      In addition, for each usable route, the stub router MUST monitor the state of reachability to the router(s) that
+	      advertised it as described in (<xref target="RFC4861" section="7.3.1" sectionFormat="comma"/>) using a ReachableTime
+	      value of no more than 60,000 milliseconds (one minute). The reason for this is that if no router providing the on-link
+	      prefix on the infrastructure link is reachable, then when a new host joins the network, it will have no usable on-link
+	      prefix to use for autoconfiguration, and thus will be unable to communicate with hosts on the stub network.</t>
+	    <t>
+	      The stub router MUST listen for router solicits on the adjacent infrastructure link. When a router solicit is
+	      received, if none of the on-link routers on the adjacent infrastructure link are marked reachable, the stub router
+	      MUST move to the STATE-BEGIN-ADVERTISING state (<xref target="state-begin-advertising"/>).</t>
+	  </section>
+	  <section anchor="state-begin-advertising">
+	    <name>IP addressability not present on adjacent infrastructure link (STATE-BEGIN-ADVERTISING)</name>
+	    <t>
+	      In this state, the stub router generates its own on-link prefix. This prefix has a valid and preferred lifetime of
+	      STUB_PROVIDED_PREFIX_LIFETIME seconds. This prefix MUST allow for autonomous configuration (SLAAC). The stub router
+	      sends a router advertisement containing this prefix, advertised as a on-link prefix, with the Stub Router bit
+	      (<xref target="I-D.hui-stub-router-ra-flag"/>) set in the prefix header. This RA MUST also include a route to the stub
+	      network. If the stub router is also a normal router (e.g. a home WiFi router), it SHOULD include all other routes that
+	      it is advertising in the RA, if there is space.</t>
+	    <t>
+	      After having sent the initial router advertisement, the stub router moves into the STATE-ADVERTISING-USABLE
+	      state (<xref target="state-advertising-usable"/>).</t>
+	  </section>
+	  <section anchor="state-advertising-usable">
+	    <name>IP addressability not present on adjacent infrastructure link (STATE-ADVERTISING-USABLE)</name>
+	    <t>
+	      The stub router sends an RA message, formatted as described in <xref target="state-begin-advertising"/>, every
+	      BEACON_INTERVAL seconds.</t>
+	    <t>
+	      The stub router may receive a router advertisement containing a usable on-link prefix on the adjacent infrastructure
+	      link. If the advertised prefix is different than the prefix the stub router is advertising as the on-link usable prefix,
+	      and the Stub Router bit is not set in the advertisement, the stub router moves to STATE-DEPRECATING (xref
+	      target="state-deprecating").</t>
+	    <t>
+	      If the stub router bit is set in the received prefix, then one of the following must be true:</t>
+	    <ul>
+	      <li>
+		The prefixes are equal. In this case, the stub router remains in STATE-ADVERTISING-USABLE.</li>
+	      <li>
+		The prefix the stub router is advertising is a ULA <xref target="RFC4193"/>, and the received prefix is a non-ULA
+		prefix. In this case, the stub router moves into the STATE-DEPRECATING (<xref target="state-deprecating"/>) state.</li>
+	      <li>
+		Both prefixes are ULA prefixes, and the received prefix, considered as a 128-bit big-endian unsigned integer,
+		is numerically lower, then the stub router moves to STATE-DEPRECATING (<xref target="state-deprecating"/>.</li>
+	      <li>
+		Otherwise the router remains in STATE-ADVERTISING-USABLE.</li>
+	    </ul>
+	  </section>
+	  <section anchor="state-deprecating">
+	    <name>Stub router deprecating its on-link prefix (STATE-DEPRECATING)</name>
+	    <t>When the stub router has detected the availability of an infrastructure-provided on-link prefix on the adjacent
+	      infrastructure link, it continues to advertise its own prefix, but deprecates it:
+	    </t>
+	    <ul>
+	      <li>
+		the preferred lifetime for this prefix should be set to zero in subsequent advertisements.</li>
+	      <li>
+		the valid lifetime for this prefix should be reduced with each subsequent advertisement</li>
+	      <li>
+		the usability of the infrastructure-provided on-link prefix should be monitored as in the STATE-USABLE state;
+		if during the deprecation period, the stub router detects that there are no longer any usable prefixes on the
+		link, it MUST return to the STATE-BEGIN-ADVERTISING (<xref target="state-advertising-usable"/>) state and resume
+		advertising its prefix with the valid and preferred lifetimes described there.</li>
+	    </ul>
+	    <t>
+	      In this state, the valid lifetime (VALID) is computed based on three values: the current time when a router
+	      advertisement is being generated (NOW), the time at which the new usable on-link prefix advertisement was received
+	      (DEPRECATE_TIME), and STUB_PROVIDED_PREFIX_LIFETIME. All of these values are in seconds. VALID is computed as follows:
+	    </t>
+	    <t>
+	      VALID = STUB_PROVIDED_PREFIX_LIFETIME - (NOW - DEPRECATE_TIME)
+	    </t>
+	    <t>
+	      If VALID is less than BEACON_INTERVAL, the stub router does not include the deprecated prefix in the router
+	      advertisement. Note that VALID could be less than zero. Otherwise, the prefix is provided in the advertisement, but with
+	      a valid lifetime of VALID.
+	    </t>
+	  </section>
 	</section>
       </section>
       <section>


### PR DESCRIPTION
Clarify meaning of discoverability.
Explain why DHCPv6-only prefixes are not "usable." Clarify why we can't treat a prefix advertised ages ago and still valid as "usable." Clarify goal of state machine.
Add a constants table and explanations for the constants. Fix an XML fail in an xref.

https://mailarchive.ietf.org/arch/msg/snac/i_LwoE-t1fZJMP4EIp99grtf_zk/