### PR TITLE
Esko Dijk: Replace acronym "BR" by "stub router" in Section 5.2.3

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -485,7 +485,7 @@
           <t>
             If DHCPv6 PD is available on the link, it is preferable to acquire a prefix using DHCPv6 PD rather than generating a
             ULA prefix, because the DHCPv6-PD-provided prefix is routable at least on the local infrastructure. Therefore, when
-            DHCPv6-PD is available, the BR MUST use DHCPv6 PD rather than its own prefix.
+            DHCPv6-PD is available, the stub router MUST use DHCPv6 PD rather than its own prefix.
           </t>
         </section>
       </section>


### PR DESCRIPTION
Closes #5