### PR TITLE
Fixes #87: let's not invent a new term for stub networks.

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -350,15 +350,15 @@
 	  <t>
 	    These two sets of information are the on-link prefix, if any, that is to be advertised. Whether or not such a prefix is
 	    advertised, and what exactly is advertised regarding that prefix, is determined by the state machine. The other set of
-	    information is a set of routes to prefixes on the SNAC network. Whenever we know of a reachable (scope is not
-	    link-local) prefix on the SNAC network, we include an RIO option in the RA on the infrastructure network indicating that
+	    information is a set of routes to prefixes on the stub network. Whenever we know of a reachable (scope is not
+	    link-local) prefix on the stub network, we include an RIO option in the RA on the infrastructure network indicating that
 	    that prefix is reachable through the SNAC router.
 	  </t>
 	  <t>
 	    It is important to note that it is possible for an on-link, routable prefix to be advertised and then withdrawn on the
-	    SNAC network, but for it to still be valid, and for there to still be some communication occurring using that prefix.
+	    stub network, but for it to still be valid, and for there to still be some communication occurring using that prefix.
 	    In order to avoid prematurely interrupting such communication, the SNAC router MUST maintain a list of prefixes known
-	    to be valid on the SNAC network, even if those prefixes have been deprecated, and MUST include RIO options for all
+	    to be valid on the stub network, even if those prefixes have been deprecated, and MUST include RIO options for all
 	    such prefixes in the RAs that it sends on the adjacent infrastructure link.
 	  </t>
 	  <section anchor="state-unknown">
@@ -625,21 +625,21 @@
 	    <t>
 	      If the DHCPv6-PD client determines that the prefix it provided to use as the OSNR prefix is no longer valid, and no
 	      replacement prefix is provided by the DHCPv6 server, then the SNAC router MUST switch to the ULA link prefix that it
-	      has allocated for use on the SNAC network.  In the case that the DHCPv6-PD client is unable to renew its lease on the
+	      has allocated for use on the stub network.  In the case that the DHCPv6-PD client is unable to renew its lease on the
 	      current OSNR prefix, and time between the T2 interval for the prefix assignment
 	      <xref target="I-D.ietf-dhc-rfc8415bis" section="21.4" sectionFormat="of"/> and the end of the lease has been
 	      reached, then the SNAC router MUST deprecate the DHCPv6-PD-provided OSNR prefix and begin advertising the ULA link
 	      prefix.
 	    </t>
 	    <t>
-	      A failure to renew the DHCPv6-PD-provided OSNR prefix could be because the SNAC network has been disconnected from one
+	      A failure to renew the DHCPv6-PD-provided OSNR prefix could be because the stub network has been disconnected from one
 	      AIL and moved to a different AIL. In this situation, if the new AIL also has IPv6 service and DHCPv6-PD service, the
 	      DHCPv6 client will get a clear indication that the old prefix is no longer valid. However, it may be that no DHCPv6-PD
 	      service is available on the new link, either because it is an IPv4-only link or because it's an IPv6-capable link that
-	      doesn't provide DHCPv6 service. In this situation, if the SNAC network remains connected to the link and no DHCPv6 service
+	      doesn't provide DHCPv6 service. In this situation, if the stub network remains connected to the link and no DHCPv6 service
 	      appears, the DHCPv6-PD-provided OSNR prefix will eventually time out and be replaced. The SNAC router SHOULD NOT attempt
 	      to replace it prior to this normal timeout process, because there is no benefit to changing the OSNR prefix on the
-	      SNAC network in such a situation, and it's possible that the SNAC router will return to the other link before the
+	      stub network in such a situation, and it's possible that the SNAC router will return to the other link before the
 	      OSNR prefix expires.
 	    </t>
         </section>
@@ -764,15 +764,15 @@
     <section>
       <name>Providing reachability to IPv4-only services to hosts on the stub network</name>
       <t>
-	SNAC networks rely on IPv6 to enable routing between links, which would not be possible with IPv4 due to the lack of a
-	standard mechanism similar to Router Advertisements in IPv4. However, it can stll be useful for hosts on the SNAC network
+	stub networks rely on IPv6 to enable routing between links, which would not be possible with IPv4 due to the lack of a
+	standard mechanism similar to Router Advertisements in IPv4. However, it can stll be useful for hosts on the stub network
 	to establish communications with IPv4-only hosts on the infrastructure network.
       </t>
       <t>
 	Although NAT64 provides IPv6-only hosts with a way to reach IPv4 hosts, there is no easy way for an IPv4 host to
-	use NAT64 to originate communication with an IPv6 host. Therefore, this document enables IPv6 hosts on the SNAC network
+	use NAT64 to originate communication with an IPv6 host. Therefore, this document enables IPv6 hosts on the stub network
 	to discover and reach with IPv4 hosts on infrastructure, but does not provide a way for IPv4-only hosts
-	on infrastructure to communicate to IPv6 hosts on the SNAC network.
+	on infrastructure to communicate to IPv6 hosts on the stub network.
       </t>
       <t>
 	This should be acceptable because hosts on the infrastructure network should not be IPv4-only, since the SNAC router is
@@ -1183,7 +1183,7 @@
         given in Section 4.2 of <xref target="RFC4861"/>:
       </t>
 	<ul>
-          <li> Router Lifetime: The SNAC router can be a default router on the SNAC network (see xref target="snac-reachability" TBD fixref).</li>
+          <li> Router Lifetime: The SNAC router can be a default router on the stub network (see xref target="snac-reachability" TBD fixref).</li>
           <li> SNAC routers do not provide DHCP service on the stub network. Therefore, the 'M' and 'O' flag bits MUST be zero.</li>
 	  <li> The 'SNAC router' flag bit xref target="I-D.ietf-6man-snac-router-bit" TBD waitRef MUST be 0.</li>
           <li> In the Cur Hop Limit field: 0</li>


### PR DESCRIPTION
As Esko pointed out, the term "SNAC network" crept in during editing a few weeks ago, and doesn't add value. This pull request changes all instances of "SNAC network" to "stub network".