### PR TITLE
Fix issue #116: Correct IPv4 router discovery statement

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -769,8 +769,9 @@
     <section>
       <name>Providing reachability to IPv4-only services to hosts on the stub network</name>
       <t>
-	stub networks rely on IPv6 to enable routing between links, which would not be possible with IPv4 due to the lack of a
-	standard mechanism similar to Router Advertisements in IPv4. However, it can stll be useful for hosts on the stub network
+	stub networks rely on IPv6 to enable routing between links, which would not be possible with IPv4 due to the limited
+	availability and functionality of IPv4 router discovery mechanisms (such as ICMP Router Discovery Messages 
+	<xref target="RFC1256"/>) compared to IPv6 Router Advertisements. However, it can still be useful for hosts on the stub network
 	to establish communications with IPv4-only hosts on the infrastructure network.
       </t>
       <t>
@@ -1011,6 +1012,7 @@
     </references>
     <references>
       <name>Informative References</name>
+      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1256.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2328.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4944.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6282.xml" />


### PR DESCRIPTION
## Summary
This PR fixes GitHub issue #116 by correcting an inaccurate statement in Section 6 about IPv4 router discovery mechanisms.

## Problem
The draft document incorrectly stated that IPv4 lacks "a standard mechanism similar to Router Advertisements," which was technically inaccurate because RFC 1256 defines ICMP Router Discovery Messages for IPv4.

## Changes Made

1. **Updated Section 6 text** to be technically accurate:
   - **Before**: "due to the lack of a standard mechanism similar to Router Advertisements in IPv4"
   - **After**: "due to the limited availability and functionality of IPv4 router discovery mechanisms (such as ICMP Router Discovery Messages RFC1256) compared to IPv6 Router Advertisements"

2. **Added RFC 1256 reference** to the informative references section to properly cite the IPv4 router discovery mechanism.

3. **Fixed a typo**: Changed "stll" to "still" in the same paragraph.

## Technical Details
The fix maintains the document's intent (explaining why IPv6 is preferred for stub networks) while being technically accurate about the existence of IPv4 router discovery mechanisms. The change acknowledges RFC 1256 as requested in the issue while explaining that IPv6 Router Advertisements are still superior in functionality.

Closes #116