### PR TITLE
Replace hardcoded /64 prefix requirement with SLAAC suitability

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -310,7 +310,7 @@
 	    values:
 	  </t>
 	  <ul>
-	    <li>Prefix Length value is 64,</li>
+	    <li>Prefix Length is suitable for IPv6 Stateless Address Autoconfiguration (SLAAC),</li>
             <li>'L' flag bit is set and</li>
 	    <li>either the 'A' flag bit or the 'P' flag bit <xref target="I-D.ietf-6man-pio-pflag"/> is set, and</li>
 	    <li>Preferred Lifetime of 30 minutes or more.</li>


### PR DESCRIPTION
## Summary
This PR addresses issue #104 by replacing the hardcoded "/64" prefix length requirement with language that focuses on IPv6 SLAAC suitability.

## Changes Made
- **Before:** `Prefix Length value is 64,`
- **After:** `Prefix Length is suitable for IPv6 Stateless Address Autoconfiguration (SLAAC),`

## Rationale
The reviewer feedback pointed out that we should focus on the functional requirement (SLAAC suitability) rather than hardcoding a specific prefix length value. This change:

1. **Improves clarity** - Better expresses what we actually care about (SLAAC compatibility)
2. **Allows flexibility** - While /64 is the standard for SLAAC in practice, this phrasing allows for potential future variations
3. **Maintains technical accuracy** - The requirement is functionally equivalent but more precise about the actual need

## Related Issues
Closes #104

## Review Focus
- Confirm the new language accurately captures the SLAAC suitability requirement
- Verify that the change maintains the technical intent of the original requirement