### PR TITLE
RECOMMEND proactive advertisement of new OSNR prefix

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -724,7 +724,7 @@
 	  In case a new OSNR prefix is configured for its stub network (i.e. one which was not previously advertised on the AIL),
 	  a SNAC router SHOULD proactively advertise this new prefix on its AIL as defined in <xref target="RFC4861" section="6.2.4" sectionFormat="of"/>,
 	  fourth paragraph. The exception case is where the SNAC router detects that another router is already advertising a route
-	  to this new OSNR prefix on the AIL: in this case, the SNAC router MAY advertise the new OSNR prefix proactively.
+	  to this new OSNR prefix on the AIL: in this case, the SNAC router is allowed to skip the proactive advertising.
 	</t>
       </section>
       <section anchor="stub-reachability">

--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -720,6 +720,11 @@
 	</t><t>
 	  A SNAC router MUST NOT advertise itself as a default router on an AIL by setting a non-zero Router Lifetime value in the
 	  header of its Router Advertisements.
+	</t><t>
+	  In case a new OSNR prefix is configured for its stub network (i.e. one which was not previously advertised on the AIL),
+	  a SNAC router SHOULD proactively advertise this new prefix on its AIL as defined in <xref target="RFC4861" section="6.2.4" sectionFormat="of"/>,
+	  fourth paragraph. The exception case is where the SNAC router detects that another router is already advertising a route
+	  to this new OSNR prefix on the AIL: in this case, the SNAC router MAY advertise the new OSNR prefix proactively.
 	</t>
       </section>
       <section anchor="stub-reachability">


### PR DESCRIPTION
This makes the proactive RA advertisement of a new OSNR prefix a SHOULD level requirement. While it's optional in RFC 4861, for a SNAC router it would be practically required to do this in order to quickly propagate routes to new OSNR prefixes on the stub network.

Closes #160