### PR TITLE
Update 'draft' references to the respective RFCs; and set DHCPv6-PD to Normative

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
-<rfc category="bcp" submissionType="IETF" docName="draft-ietf-snac-simple-06" ipr="trust200902"
+<rfc category="bcp" submissionType="IETF" docName="draft-ietf-snac-simple-09" ipr="trust200902"
      xmlns:xi="http://www.w3.org/2001/XInclude" version="3"
      scripts="Common,Latin" sortRefs="false" consensus="true"
      symRefs="true" tocDepth="3" tocInclude="true" xml:lang="en">
@@ -34,7 +33,7 @@
       </address>
     </author>
 
-    <date year='2024'/>
+    <date year='2026'/>
     <area>Internet</area>
     <workgroup>Internet Engineering Task Force</workgroup>
     <abstract>
@@ -366,7 +365,7 @@
 	  <ul>
 	    <li>Prefix Length is 64, suitable for IPv6 Stateless Address Autoconfiguration (SLAAC), consistent with current implementations and <xref target="RFC4291" section="2.5.1"/> 64bit Interface Identifiers</li>
             <li>'L' flag bit is set and</li>
-	    <li>either the 'A' flag bit or the 'P' flag bit <xref target="I-D.ietf-6man-pio-pflag"/> is set, and</li>
+	    <li>either the 'A' flag bit or the 'P' flag bit <xref target="RFC9762"/> is set, and</li>
 	    <li>Preferred Lifetime of MIN_SUITABLE_PREFIX_PREFERRED_LIFETIME or more.</li>
 	  </ul>
 	  <t>
@@ -377,7 +376,7 @@
 		  If the 'P' flag bit is set, then hosts that wish to allocate their own addresses can do so by
 		  acquiring a prefix from which to allocate them using DHCPv6 prefix delegation <xref target="RFC9663"/>.
 		  Nodes are not required to use DHCPv6 to acquire individual addresses, so a
-	    prefix that requires the use of DHCPv6 for that purpose can't be considered "suitable"&mdash;not all hosts can actually use it.
+	    prefix that requires the use of DHCPv6 for that purpose can't be considered "suitable"—not all hosts can actually use it.
 	  </t>
 	  <t>
 	    Note: there can be layer two networks where neighbor discovery is not supported and therefore the 'L' flag bit cannot be set,
@@ -648,7 +647,7 @@
           </t><t>
             A SNAC router MUST request stub network prefixes with length 64. It does so by sending an IA_PD option for each prefix,
             each with a different IAID, containing an IA Prefix option with a hint for length 64 as described in
-            <xref target="I-D.ietf-dhc-rfc8415bis" section="18.2.1" sectionFormat="of"/>. If the SNAC router obtains a prefix with length less
+            <xref target="RFC9915" section="18.2.1" sectionFormat="of"/>. If the SNAC router obtains a prefix with length less
             than 64, it SHOULD generate a /64 from the obtained prefix by padding with zeros. If the SNAC router obtains a prefix
             with length greater than 64, the SNAC router MUST treat the prefix as unsuitable and allocate a ULA link prefix out of
             its ULA site prefix instead.
@@ -677,7 +676,7 @@
 	    <t>
 	      It is possible that a SNAC router might obtain a prefix from a DHCPv6 server using prefix delegation and then something
 	      about the infrastructure network attachment might change that affects the validity of that prefix for use on the stub
-	      network. The section of <xref target="I-D.ietf-dhc-rfc8415bis"/> titled "Refreshing Configuration Information"
+	      network. The section of <xref target="RFC9915"/> titled "Refreshing Configuration Information"
 	      discusses the various scenarios that can occur. The DHCPv6 prefix delegation client being used by
 	      the SNAC router is assumed to conform to this specification.
 	    </t>
@@ -698,7 +697,7 @@
 	      replacement prefix is provided by the DHCPv6 server, then the SNAC router MUST switch to the ULA link prefix that it
 	      has allocated for use on the stub network.  In the case that the DHCPv6-PD client is unable to renew its lease on the
 	      current OSNR prefix, and time between the T2 interval for the prefix assignment
-	      <xref target="I-D.ietf-dhc-rfc8415bis" section="21.4" sectionFormat="of"/> and the end of the lease has been
+	      <xref target="RFC9915" section="21.4" sectionFormat="of"/> and the end of the lease has been
 	      reached, then the SNAC router MUST deprecate the DHCPv6-PD-provided OSNR prefix and begin advertising the ULA link
 	      prefix.
 	    </t>
@@ -803,7 +802,7 @@
 	    MUST be provided using an Advertising Proxy, as defined in <xref target="I-D.ietf-dnssd-advertising-proxy"/>.</t>
 	  <t>
 	    One limitation of this solution is that it requires that hosts on the stub network use the DNS-SD Service Registration
-	    Protocol <xref target="I-D.ietf-dnssd-srp"/> to register their DNS-SD advertisements. This means that in the case of a
+	    Protocol (SRP) <xref target="RFC9665"/> to register their DNS-SD advertisements. This means that in the case of a
 	    stub network used for WiFi tethering, hosts on the stub network will not be discoverable by hosts on the infrastructure
 	    network. Any solution to this problem would require that the SNAC router provide a Discovery Proxy <xref target="RFC8766"/>.
 	    However, a discovery proxy is queried using DNS, not mDNS. This requires assistance from the infrastructure network,
@@ -1084,11 +1083,12 @@
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8766.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8781.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9499.xml" />
-      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-dnssd-srp.xml" />
+	  <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9663.xml" />
+	  <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9665.xml" />
+      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9762.xml" />
+      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9915.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-dnssd-advertising-proxy.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-6man-snac-router-ra-flag.xml" />
-      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-dhc-rfc8415bis.xml" />
-      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-6man-pio-pflag.xml" />
     </references>
     <references>
       <name>Informative References</name>
@@ -1096,7 +1096,6 @@
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2328.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.4944.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6282.xml" />
-      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9663.xml" />
     </references>
 
     <section anchor="net-analysis">


### PR DESCRIPTION
DHCPv6-PD needs be a normative reference since it's required 'MUST' for the SNAC router.
Also draft references are updated to the respective RFCs.

To remove some XML2RFC v3 warnings the XML DOCTYPE line is deleted because it's no longer supposed to be used since v3 tooling. But, that broke the 'mdash' element parsing. So the 'mdash' XML element is now replaced by the actual emdash unicode character which is allowed because the first line states the XML document is UTF-8 encoded!