### PR TITLE
Provide a fix for the RFC 4861 problem of effectively fixed initial rtr interval.

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -422,7 +422,7 @@
 	    such prefixes in the RAs that it sends on the adjacent infrastructure link.
 	  </t>
       <t>
-		When a SNAC router enables its AIL interface as advertising interface and determines it needs to send unsolicited RAs
+		When a SNAC router enables its AIL interface as an advertising interface and determines it needs to send unsolicited RAs
 		per <xref target="RFC4861" section="6.2.4" sectionFormat="of"/>, it MUST use a random delay between
 		0 and MAX_INITIAL_RTR_ADVERT_INTERVAL, instead of the effectively fixed delay of MAX_INITIAL_RTR_ADVERT_INTERVAL
 		currently specified by <xref target="RFC4861"/>.

--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -421,6 +421,12 @@
 	    to be valid on the stub network, even if those prefixes have been deprecated, and MUST include RIO options for all
 	    such prefixes in the RAs that it sends on the adjacent infrastructure link.
 	  </t>
+      <t>
+		When a SNAC router enables its AIL interface as advertising interface and determines it needs to send unsolicited RAs
+		per <xref target="RFC4861" section="6.2.4" sectionFormat="of"/>, it MUST use a random delay between
+		0 and MAX_INITIAL_RTR_ADVERT_INTERVAL, instead of the effectively fixed delay of MAX_INITIAL_RTR_ADVERT_INTERVAL
+		currently specified by <xref target="RFC4861"/>.
+	  </t>
 	  <section anchor="state-unknown">
 	    <name>Status of IP addressability on adjacent infrastructure link unknown (STATE-UNKNOWN)</name>
 	    <t>
@@ -604,17 +610,17 @@
 	    the router configures the prefix on its interface but does not advertise it in Router Advertisements. Devices that are
 	    still using that prefix will be seen as on-link to the router, and so packets will be delivered using ND on-link rather
 	    than forwarded to the default router.
-	  </t><t>
+      </t><t>
 	    When a SNAC router has only flash memory with limited write lifetime, it may be inappropriate to do a write to flash
 	    every time a multicast RA message containing a prefix is sent. In this case, the router SHOULD record the set of prefixes that
 	    have been advertised on infrastructure and the maximum valid lifetime that was advertised. On restart, the router should
 	    assume that hosts on the infrastructure link have received advertisements for any such prefixes.
 	  </t><t>
-            When possible, it is best if all SNAC routers serving a particular stub network use the same 64-bit prefix on the
-            AIL. For example, Thread SNAC routers use bits from the Thread Extended PAN ID to generate the ULA prefix's Global ID
-            and Subnet ID. The Global ID generation conforms to <xref target="RFC4193"/> because the Extended PAN ID is generated
-            randomly using the same mechanism that is specified in RFC 4193 for the ULA prefix bits.
-          </t>
+	    When possible, it is best if all SNAC routers serving a particular stub network use the same 64-bit prefix on the
+	    AIL. For example, Thread SNAC routers use bits from the Thread Extended PAN ID to generate the ULA prefix's Global ID
+	    and Subnet ID. The Global ID generation conforms to <xref target="RFC4193"/> because the Extended PAN ID is generated
+	    randomly using the same mechanism that is specified in RFC 4193 for the ULA prefix bits.
+	  </t>
 	</section>
 	<section anchor="ula-site-prefix">
 	  <name>Generating a per-SNAC-router ULA Site Prefix</name>


### PR DESCRIPTION
Note that the 2nd block is just whitespace corrections.