### PR TITLE
Move 'maintenance across restarts' to a common section

### DIFF
--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -229,8 +229,10 @@
       </section>
     </section>
 
-    <section>
+    <section anchor="glossary">
       <name>Glossary</name>
+	<t>This section contains a glossary of terms used in this document.
+	   See <xref target="conventions"/> for document conventions and remaining terms and definitions.</t>
       <dl>
 	<dt>Node:</dt>
 	<dd>A device that implements IPv6.</dd>
@@ -344,7 +346,7 @@
       </dl>
     </section>
 
-    <section>
+    <section anchor="conventions">
       <name>Conventions and Terminology Used in This Document</name>
       <t>
 	The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
@@ -355,6 +357,9 @@
 	The terms "resolver" and "stub resolver" used in this document are defined in <xref target="RFC9499"/>.
 	"DNS resolver" is used as a synonym for "resolver" to clearly point out the DNS context of this term.
       </t>
+      <t>
+	The term "advertising interface" is used as defined in <xref target="RFC4861" section="6.2.2"/>.
+	  </t>
     </section>
 
     <section anchor="common-maint">
@@ -363,10 +368,9 @@
 	This document assumes that the AIL supports Neighbor Discovery <xref target="RFC4861"/>, and specifically that
 	routers and on-link prefixes can be advertised using Router Advertisement messages and discovered using Router Solicitation messages. The stub
 	network link may also support this, or may use some different mechanism. This section specifies how advertisement of the
-	on-link prefix for such links is managed. In this section the term "advertising interface" is used as defined in
-	<xref target="RFC4861" section="6.2.2"/>.</t>
+	on-link prefix for such links is managed.</t>
       <t>
-	When a SNAC router sends a Router Advertisement (RA) message as specified in any of the below subsections, it
+	When a SNAC router sends a Router Advertisement (RA) message as specified in this document, it
 	MUST NOT use multiple RA messages with each containing a subset of the options. Such splitting behavior is specified in
 	<xref target="RFC4861" section="6.2.3"/>. Instead, all options are always included in a single RA message.
 	Multiple RA messages with different information contents are only sent to indicate that previously sent information changed.</t>
@@ -381,14 +385,14 @@
 	  second SNAC router&apos;s prefix is advertised on the infrastructure link, and therefore does not advertise its own.
 	</t><t>
 	  This behavior can cause problems because the first SNAC router no longer sees the on-link prefix it had been advertising
-	  on infrastructure as on-link. Consequently, if it receives a packet on the stub network with such a destation address, it
+	  on infrastructure as on-link. Consequently, if it receives a packet on the stub network with such a destination address, it
 	  will forward that packet directly to a default router, if one is present; otherwise, it will have no route to the
 	  destination, and will drop the packet.
 	</t><t>
-	  This amounts to a flash renumbering event. There is no easy to prevent this happening: routes and prefixes advertised in
+	  This amounts to a flash renumbering event. There is no easy way to prevent this from happening: routes and prefixes advertised in
 	  router advertisements have lifetimes, and hosts may continue to use such prefixes until they expire. Applications that
 	  are not able to detect the loss of a route or that do not quickly notice that a host is no longer reachable on a particular
-	  address will exhibit poor performance when this happens. For example, if the stub network is an network that supports
+	  address will exhibit poor performance when this happens. For example, if the stub network is a network that supports
 	  IoT devices, the user may experience temporary inability to control such devices, and automations may fail.
 	</t><t>
 	  When possible, it is best if all SNAC routers serving a particular stub network use the same /64 on-link prefix for the
@@ -408,8 +412,8 @@
 	  updated. In this case, if other SNAC routers are present, they can continue to advertise routes to that prefix on the stub
 	  network. If possible, the original OSNR prefix SHOULD be preserved until the SNAC router that advertised it returns. However,
 	  if a host on the stub network multicasts a Router Solicitation message to the link and the SNAC router advertising the OSNR
-	  prefix is still not present, or if the OSNR prefix is in danger of expiring, another SNAC router must take over and
-	  advertise its OSNR prefix. In this situation, SNAC routers that remember the old OSNR prefix should continue advertising a
+	  prefix is still not present, or if the OSNR prefix is in danger of expiring, another SNAC router needs to take over and
+	  advertise its OSNR prefix. In this situation, SNAC routers that remember the old OSNR prefix continue advertising a
 	  route to it on the AIL until the OSNR prefix expires.
         </t>
       </section>

--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -357,8 +357,8 @@
       </t>
     </section>
 
-    <section anchor="support-ail">
-      <name>Support for adjacent infrastructure links</name>
+    <section anchor="common-maint">
+      <name>Maintenance of addressability on AIL and stub network links</name>
       <t>
 	This document assumes that the AIL supports Neighbor Discovery <xref target="RFC4861"/>, and specifically that
 	routers and on-link prefixes can be advertised using Router Advertisement messages and discovered using Router Solicitation messages. The stub
@@ -370,6 +370,53 @@
 	MUST NOT use multiple RA messages with each containing a subset of the options. Such splitting behavior is specified in
 	<xref target="RFC4861" section="6.2.3"/>. Instead, all options are always included in a single RA message.
 	Multiple RA messages with different information contents are only sent to indicate that previously sent information changed.</t>
+      <section>
+	<name>Maintenance across SNAC router restarts</name>
+	<t>
+	  SNAC routers may restart from time to time; when a restart occurs, the SNAC router may have been advertising state to the
+	  network which, following the restart, is no longer required.
+	</t><t>
+	  For example, suppose there are two SNAC routers connected to the same infrastructure link. When the first SNAC router is
+	  restarted, the second takes over providing an on-link prefix. Now the first router rejoins the link. It sees that the
+	  second SNAC router&apos;s prefix is advertised on the infrastructure link, and therefore does not advertise its own.
+	</t><t>
+	  This behavior can cause problems because the first SNAC router no longer sees the on-link prefix it had been advertising
+	  on infrastructure as on-link. Consequently, if it receives a packet on the stub network with such a destation address, it
+	  will forward that packet directly to a default router, if one is present; otherwise, it will have no route to the
+	  destination, and will drop the packet.
+	</t><t>
+	  This amounts to a flash renumbering event. There is no easy to prevent this happening: routes and prefixes advertised in
+	  router advertisements have lifetimes, and hosts may continue to use such prefixes until they expire. Applications that
+	  are not able to detect the loss of a route or that do not quickly notice that a host is no longer reachable on a particular
+	  address will exhibit poor performance when this happens. For example, if the stub network is an network that supports
+	  IoT devices, the user may experience temporary inability to control such devices, and automations may fail.
+	</t><t>
+	  When possible, it is best if all SNAC routers serving a particular stub network use the same 64-bit prefix on the
+	  AIL. For example, Thread <xref target="Thread"/> SNAC routers use bits from the Thread Extended PAN ID to generate the ULA prefix's Global ID
+	  and Subnet ID. The Global ID generation conforms to <xref target="RFC4193"/> because the Extended PAN ID is generated
+	  randomly using the same mechanism that is specified in RFC 4193 for the ULA prefix bits.
+	</t>
+	<t>
+	  Because the Extended PAN ID is a stable value that identifies the Thread network, it can be safely used to number the
+	  infrastructure link when no other sutable prefix is available, and since it can be maintained by all Thread routers, there
+	  is no problem with changes to the on-link prefix. Of course, when SNAC routers supporting more than one such network are
+	  present, the problem still exists in principle, but as long as all SNAC routers supporting a single link do not restart at
+	  the same time, the prefix can be expected to remain stable.
+	</t>
+	<t>
+	  Similarly, it can be the case while a SNAC router is advertising the OSNR prefix on the stub network, it is rebooted or
+	  updated. In this case, if other SNAC routers are present, they can continue to advertise routes to that prefix on the stub
+	  network. If possible, the original prefix SHOULD be preserved until the SNAC router that advertised it returns. However,
+	  if a host on the stub network multicasts a Router Solicitation message to the link and the router advertising the OSNR
+	  prefix is still not present, or if the OSNR prefix is in danger of expiring, another SNAC router must take over and
+	  advertise its OSNR prefix. In this situation, SNAC routers that remember the old prefix should continue advertising a
+	  route to on the AIL until it expires.
+        </t>
+      </section>
+    </section>
+
+    <section anchor="support-ail">
+      <name>Support for adjacent infrastructure links</name>
       <t>
 	Support for AILs on networks where Neighbor Discovery is not supported is out of scope for this document. SNAC routers
 	do not provide routing between AILs when connected to more than one such link.</t>
@@ -628,37 +675,6 @@
 	  such networks is out of scope for this document.
       Some informative discussion on this topic is in <xref target="appendix-failure-change"/>.
 	</t>
-	<section>
-	  <name>Maintenance across SNAC router restarts</name>
-	  <t>
-	    SNAC routers may restart from time to time; when a restart occurs, the SNAC router may have been advertising state to the
-	    network which, following the restart, is no longer required.
-	  </t><t>
-	    For example, suppose there are two SNAC routers connected to the same infrastructure link. When the first SNAC router is
-	    restarted, the second takes over providing an on-link prefix. Now the first router rejoins the link. It sees that the
-	    second SNAC router&apos;s prefix is advertised on the infrastructure link, and therefore does not advertise its own.
-	  </t><t>
-	    This behavior can cause problems because the first SNAC router no longer sees the on-link prefix it had been
-	    advertising on infrastructure as on-link. Consequently, if it receives a packet to forward to such an address, it will
-	    forward that packet directly to a default router, if one is present; otherwise, it will have no route to the destination,
-	    and will drop the packet.
-	  </t><t>
-	    To address this problem, SNAC routers SHOULD remember the last time a prefix was advertised across restarts. On restart,
-	    the router configures the prefix on its interface but does not advertise it in Router Advertisements. Devices that are
-	    still using that prefix will be seen as on-link to the router, and so packets will be delivered using ND on-link rather
-	    than forwarded to the default router.
-      </t><t>
-	    When a SNAC router has only flash memory with limited write lifetime, it may be inappropriate to do a write to flash
-	    every time a multicast RA message containing a prefix is sent. In this case, the router SHOULD record the set of prefixes that
-	    have been advertised on infrastructure and the maximum valid lifetime that was advertised. On restart, the router should
-	    assume that hosts on the infrastructure link have received advertisements for any such prefixes.
-	  </t><t>
-	    When possible, it is best if all SNAC routers serving a particular stub network use the same 64-bit prefix on the
-	    AIL. For example, Thread <xref target="Thread"/> SNAC routers use bits from the Thread Extended PAN ID to generate the ULA prefix's Global ID
-	    and Subnet ID. The Global ID generation conforms to <xref target="RFC4193"/> because the Extended PAN ID is generated
-	    randomly using the same mechanism that is specified in RFC 4193 for the ULA prefix bits.
-	  </t>
-	</section>
 	<section anchor="ula-site-prefix">
 	  <name>Generating a per-SNAC-router ULA Site Prefix</name>
 	  <t>

--- a/draft-ietf-snac-simple.xml
+++ b/draft-ietf-snac-simple.xml
@@ -391,26 +391,26 @@
 	  address will exhibit poor performance when this happens. For example, if the stub network is an network that supports
 	  IoT devices, the user may experience temporary inability to control such devices, and automations may fail.
 	</t><t>
-	  When possible, it is best if all SNAC routers serving a particular stub network use the same 64-bit prefix on the
+	  When possible, it is best if all SNAC routers serving a particular stub network use the same /64 on-link prefix for the
 	  AIL. For example, Thread <xref target="Thread"/> SNAC routers use bits from the Thread Extended PAN ID to generate the ULA prefix's Global ID
 	  and Subnet ID. The Global ID generation conforms to <xref target="RFC4193"/> because the Extended PAN ID is generated
 	  randomly using the same mechanism that is specified in RFC 4193 for the ULA prefix bits.
 	</t>
 	<t>
 	  Because the Extended PAN ID is a stable value that identifies the Thread network, it can be safely used to number the
-	  infrastructure link when no other sutable prefix is available, and since it can be maintained by all Thread routers, there
-	  is no problem with changes to the on-link prefix. Of course, when SNAC routers supporting more than one such network are
-	  present, the problem still exists in principle, but as long as all SNAC routers supporting a single link do not restart at
-	  the same time, the prefix can be expected to remain stable.
+	  infrastructure link when no other suitable on-link prefix is available, and since it can be maintained by all Thread SNAC routers, there
+	  are no problems due to a change of the AIL on-link prefix. Of course, when SNAC routers supporting more than one such stub network are
+	  present, the problem still exists in principle, but as long as all SNAC routers supporting a single stub network do not restart at
+	  the same time, the AIL on-link prefix can be expected to remain stable.
 	</t>
 	<t>
-	  Similarly, it can be the case while a SNAC router is advertising the OSNR prefix on the stub network, it is rebooted or
+	  Similarly, it can be the case that while a SNAC router is advertising the OSNR prefix on the stub network, it is rebooted or
 	  updated. In this case, if other SNAC routers are present, they can continue to advertise routes to that prefix on the stub
-	  network. If possible, the original prefix SHOULD be preserved until the SNAC router that advertised it returns. However,
-	  if a host on the stub network multicasts a Router Solicitation message to the link and the router advertising the OSNR
+	  network. If possible, the original OSNR prefix SHOULD be preserved until the SNAC router that advertised it returns. However,
+	  if a host on the stub network multicasts a Router Solicitation message to the link and the SNAC router advertising the OSNR
 	  prefix is still not present, or if the OSNR prefix is in danger of expiring, another SNAC router must take over and
-	  advertise its OSNR prefix. In this situation, SNAC routers that remember the old prefix should continue advertising a
-	  route to on the AIL until it expires.
+	  advertise its OSNR prefix. In this situation, SNAC routers that remember the old OSNR prefix should continue advertising a
+	  route to it on the AIL until the OSNR prefix expires.
         </t>
       </section>
     </section>


### PR DESCRIPTION
This pull request moves the 'maintenance across restarts' section to the beginning and moves some common paragraphs from the AIL support section (previously section 5) before that to serve as an introduction, since those paragraphs were also generally applicable.

It further rewrites this section to avoid specifying behavior that didn't work well and is no longer used in existing deployments.

Closes #152
Closes #155 